### PR TITLE
Add autoload to make the theme show in load-theme menu

### DIFF
--- a/cyberpunk-2019-theme.el
+++ b/cyberpunk-2019-theme.el
@@ -126,6 +126,12 @@
  `(helm-selection ((t ( :background "#FF9C00" :foreground "#FFFAFA" :underline nil))))
  )
 
+;; Makes sure that the theme is loaded
+;;;###autoload
+(when load-file-name
+  (add-to-list 'custom-theme-load-path
+               (file-name-as-directory (file-name-directory load-file-name))))
+
 (provide-theme 'cyberpunk-2019)
 
 ;;; cyberpunk-2019-theme.el ends here


### PR DESCRIPTION
Fixes #4 
The `autoload` added makes sure that the theme appears in the load theme menu.  I took a look as to what the difference is and after looking at the [monokai](https://github.com/oneKelvinSmith/monokai-emacs/blob/f4ef092129f4a35edaee0a9b2219c17e86309730/monokai-theme.el#L6081) and some of the [spacemacs themes](https://github.com/nashamri/spacemacs-theme/blob/3eae3726faf39aa2a9e4c919a657f335282fefb7/spacemacs-common.el#L967), the only difference was that autoload.